### PR TITLE
Compass Compile errors are shown to the user

### DIFF
--- a/SassyStudio.2012/Integration/Compass/CompassDocumentCompiler.cs
+++ b/SassyStudio.2012/Integration/Compass/CompassDocumentCompiler.cs
@@ -46,11 +46,13 @@ namespace SassyStudio.Integration.Compass
                 if (executor.ExitCode != 0)
                 {
                     var message = "Compass returned an error.";
-                    if (errorOutput.Length > 0)
+                    
+                    if (errorOutput.ToString().Trim().Length > 0)
                     {
                         message += Environment.NewLine + errorOutput.ToString();
                     }
-                    else if (standardOutput.Length > 0)
+                    
+                    if (standardOutput.ToString().Trim().Length > 0)
                     {
                         message += Environment.NewLine + standardOutput.ToString();
                     }


### PR DESCRIPTION
When compass returns a compile error it seems to do so in standardOutput.

The issue is that SassyStudio only outputs the errorOutput OR the standardOutput. If the errorOutput.Length is greater than zero then the standardOutput is never displayed to the user. It seems that the errorOutput.Length is always greater than zero (because of newline characters).
